### PR TITLE
Fix error state infinite recomposition

### DIFF
--- a/kamel-image/src/commonMain/kotlin/io/kamel/image/LazyPainterResource.kt
+++ b/kamel-image/src/commonMain/kotlin/io/kamel/image/LazyPainterResource.kt
@@ -24,10 +24,14 @@ public inline fun lazyPainterResource(data: Any, key: Any? = data, block: Resour
 
     var painterResource by remember(key) { mutableStateOf<Resource<Painter>>(Resource.Loading) }
 
-    val resourceConfig = ResourceConfigBuilder()
-        .apply { density = LocalDensity.current }
-        .apply(block)
-        .build()
+    val density = LocalDensity.current
+
+    val resourceConfig = remember(key, density) {
+        ResourceConfigBuilder()
+            .apply { this.density = density }
+            .apply(block)
+            .build()
+    }
 
     val kamelConfig = LocalKamelConfig.current
 


### PR DESCRIPTION
This PR attempts to fix issue #9, where a network error would cause the images to be retried infinitely. The issue contains more info on how to reproduce the problem in order to test the fix.

From my investigation, the bug was caused because `resourceConfig` was recreated on every composition. Since it is used as a key for the `LaunchedEffect` in `loadPainterResource`, that effect would be restarted on every composition, which we really don't want.