### PR TITLE
Output cached result immediately, if available.

### DIFF
--- a/kamel-core/src/commonMain/kotlin/io/kamel/core/ImageLoading.kt
+++ b/kamel-core/src/commonMain/kotlin/io/kamel/core/ImageLoading.kt
@@ -79,3 +79,18 @@ private inline fun <reified T : Any> KamelConfig.loadResource(
         emitAll(dataFlow)
     }
 }.catch { emit(Resource.Failure(it)) }
+
+/**
+ * Loads a cached [ImageBitmap], [ImageVector], or SVG [Painter] from memory. This includes mapping and loading the
+ * cached image resource. If no resource has been cached for the provided data, `null` is returned.
+ * @see Mapper
+ * @see Cache
+ */
+public fun <T : Any> KamelConfig.loadCachedResourceOrNull(
+    data: Any,
+    cache: Cache<Any, T>,
+    dataKClass: KClass<*> = data::class,
+): Resource<T>? {
+    val output = mapInput(data, dataKClass)
+    return cache[output]?.let { Resource.Success(it, DataSource.Memory) }
+}

--- a/kamel-image/src/commonMain/kotlin/io/kamel/image/LazyPainterResource.kt
+++ b/kamel-image/src/commonMain/kotlin/io/kamel/image/LazyPainterResource.kt
@@ -52,13 +52,21 @@ public inline fun <I : Any> lazyPainterResource(
             .build()
     }
 
+    val cachedResource = remember(key) {
+        when (data.toString().substringAfterLast(".")) {
+            "svg" -> kamelConfig.loadCachedResourceOrNull(data, kamelConfig.svgCache)
+            "xml" -> kamelConfig.loadCachedResourceOrNull(data, kamelConfig.imageVectorCache)
+            else -> kamelConfig.loadCachedResourceOrNull(data, kamelConfig.imageBitmapCache)
+        }
+    }
+
     val painterResource by remember(key, resourceConfig) {
         when (data.toString().substringAfterLast(".")) {
             "svg" -> kamelConfig.loadSvgResource(data, resourceConfig)
             "xml" -> kamelConfig.loadImageVectorResource(data, resourceConfig)
             else -> kamelConfig.loadImageBitmapResource(data, resourceConfig)
         }
-    }.collectAsState(Resource.Loading(0F), resourceConfig.coroutineContext)
+    }.collectAsState(cachedResource ?: Resource.Loading(0F), resourceConfig.coroutineContext)
 
     val painterResourceWithFallbacks = when (painterResource) {
         is Resource.Loading -> {


### PR DESCRIPTION
Currently the `lazyPainterResource` will always result in at least 2
compositions even when the painter is already cached: the first one
always returns Resource.Loading, while the second one is the actual
Resource.Success containing the cached Painter.

By looking up the cached Painter ahead of time and using that as the
initial value if it exists, we skip a recomposition for preloaded
Painters and avoid a UI flash in some cases where an external factor
causes a recomposition.
