### PR TITLE
Replaced Stately ConcurrentMutableMap with Ktor ConcurrentMap

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ agp = "8.1.4"
 
 okio = "3.6.0"
 startup-runtime = "1.1.1"
-stately-concurrent-collections = "2.0.5"
 vanniktech-publish = "0.25.3"
 multiplatform-resources = "0.23.0"
 compose = "1.5.11"
@@ -35,7 +34,6 @@ batik = "1.17"
 cache4k = { module = "io.github.reactivecircus.cache4k:cache4k", version.ref = "cache4k" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
-stately-concurrent-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately-concurrent-collections" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

--- a/kamel-core/build.gradle.kts
+++ b/kamel-core/build.gradle.kts
@@ -67,7 +67,6 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.okio)
                 implementation(libs.cache4k)
-                implementation(libs.stately.concurrent.collections)
             }
         }
 

--- a/kamel-core/src/commonMain/kotlin/io/kamel/core/cache/disk/DiskLruCache.kt
+++ b/kamel-core/src/commonMain/kotlin/io/kamel/core/cache/disk/DiskLruCache.kt
@@ -1,6 +1,5 @@
 package io.kamel.core.cache.disk
 
-import co.touchlab.stately.collections.ConcurrentMutableMap
 import io.ktor.utils.io.core.Closeable
 import io.ktor.utils.io.errors.IOException
 
@@ -23,7 +22,7 @@ import io.ktor.utils.io.errors.IOException
 
 import io.kamel.core.utils.createFile
 import io.kamel.core.utils.deleteContents
-import io.ktor.util.collections.*
+import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -148,7 +147,7 @@ internal class DiskLruCache(
     private val journalFile = directory / JOURNAL_FILE
     private val journalFileTmp = directory / JOURNAL_FILE_TMP
     private val journalFileBackup = directory / JOURNAL_FILE_BACKUP
-    private val lruEntries = ConcurrentMutableMap<String, Entry>()
+    private val lruEntries = ConcurrentMap<String, Entry>()
     private val cleanupScope = CoroutineScope(SupervisorJob() + cleanupDispatcher)
     private var size = 0L
     private var operationsSinceRewrite = 0


### PR DESCRIPTION
The Stately's implementation does not work properly on JVM targets causing ConcurrentModificationException

https://github.com/touchlab/Stately/issues/105
https://github.com/Kamel-Media/Kamel/issues/75

I've only tested it on the JVM targets and I was not able to reproduce the problem.